### PR TITLE
Criando arquivo phpcs.xml

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+
+  <description>PHP_CodeSniffer configuration</description>
+
+    <rule ref="PSR2">
+        <exclude name="PEAR.Functions.FunctionCallSignature"/>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
Utilizar as regas do PHPCS para validar o que se espera. (ex: PSR2) e com a própria biblioteca do PHP CS (https://github.com/squizlabs/PHP_CodeSniffer) já deixar o composer e os testes para garantirem o esperado.